### PR TITLE
Fix gomod2nix deps; housekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ In case you still want to use it, instructions are below:
 ### From source
 
 1. Download Go. You can find it [here](https://golang.org/dl/)
-2. Clone this repository with `git clone https://github.com/notashelf/hyprkeys`
+2. Clone this repository with `git clone https://github.com/hyprland-community/hyprkeys`
 3. Install the application with `make build` then `sudo make install`
-4. You can run the application with `hyprland`
+4. You can run the application with `hyprkeys`
 
 ### Using nix
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,16 @@ In case you still want to use it, instructions are below:
 
 ## Installation & Usage
 
+### From source
+
 1. Download Go. You can find it [here](https://golang.org/dl/)
 2. Clone this repository with `git clone https://github.com/notashelf/hyprkeys`
 3. Install the application with `make build` then `sudo make install`
-5. You can run the application with `hyprland`
+4. You can run the application with `hyprland`
+
+### Using nix
+
+`nix run github:hyprland-community/Hyprkeys`
 
 ## Project Roadmap
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -14,7 +14,7 @@
 }:
 pkgs.buildGoApplication {
   pname = "Hyprkeys";
-  version = "1.0.0";
+  version = "1.0.1";
   pwd = ../.;
   src = ../.;
   modules = ./gomod2nix.toml;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,6 +10,7 @@
         ];
       }
   ),
+  lib,
 }:
 pkgs.buildGoApplication {
   pname = "Hyprkeys";
@@ -17,4 +18,6 @@ pkgs.buildGoApplication {
   pwd = ../.;
   src = ../.;
   modules = ./gomod2nix.toml;
+
+  meta = with lib; {mainProgram = "hyprkeys";};
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -19,5 +19,11 @@ pkgs.buildGoApplication {
   src = ../.;
   modules = ./gomod2nix.toml;
 
-  meta = with lib; {mainProgram = "hyprkeys";};
+  meta = with lib; {
+    mainProgram = "hyprkeys";
+    license = licenses.mit;
+    description = "A simple, scriptable keybind retrieval utility for Hyprland";
+    homepage = "https://github.com/hyprland-community/${pname}";
+    changelog = "https://github.com/hyprland-community/${pname}/releases/tag/v${version}";
+  };
 }

--- a/nix/gomod2nix.toml
+++ b/nix/gomod2nix.toml
@@ -1,12 +1,12 @@
 schema = 3
 
 [mod]
-  [mod."github.com/oleiade/reflections"]
+  [mod."github.com/inconshreveable/mousetrap"]
     version = "v1.0.1"
-    hash = "sha256-KXdvV9qMWUoQGQAtA/+wxySz8H3Ysgs2L6YwoquBfH0="
-  [mod."github.com/pborman/getopt"]
-    version = "v1.1.0"
-    hash = "sha256-hMWyrsk88xecOyTnMrVqwG35TSyVU+G9vmRWpmrI4N4="
-  [mod."github.com/stretchr/testify"]
-    version = "v1.8.1"
-    hash = "sha256-3e0vOJLgCMAan+GfaGN8RGZdarh5iCavM6flf6YMNPk="
+    hash = "sha256-ZTP9pLgwAAvHYK5A4PqwWCHGt00x5zMSOpCPoomQ3Sg="
+  [mod."github.com/spf13/cobra"]
+    version = "v1.6.1"
+    hash = "sha256-80B5HcYdFisz6QLYkTyka7f9Dr6AfcVyPwp3QChoXwU="
+  [mod."github.com/spf13/pflag"]
+    version = "v1.0.5"
+    hash = "sha256-w9LLYzxxP74WHT4ouBspH/iQZXjuAh2WQCHsuvyEjAw="


### PR DESCRIPTION
The dependencies gomod2nix tried to use deviated from the actual ones after the switch to cobra.
This PR updates the `gomod2nix.toml`.

I also went ahead and added some metadata to the package.
It should now be possible to be run with `nix run` (when in the repo) or `nix run github:hyprland-community/Hyprkeys`.